### PR TITLE
change workdir to correctly delete build directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,7 @@ RUN env \
 RUN git clone --depth=1 -b $BRANCH_OR_TAG -q https://github.com/google/googletest.git /googletest
 RUN mkdir -p /googletest/build
 WORKDIR /googletest/build
-RUN cmake .. && make && make install \
-  && rm -rf /googletest
+RUN cmake .. && make && make install
+RUN mkdir -p /code
+WORKDIR /code
+RUN rm -rf /googletest


### PR DESCRIPTION
/googletest is not removed because it is still the workdir. Change to /code first